### PR TITLE
fix for Page Title module and other modules that set head_title

### DIFF
--- a/template.php
+++ b/template.php
@@ -52,7 +52,7 @@ function bootstrap_preprocess_html(&$vars) {
     $vars['classes_array'][] = 'with-navbar';
   }
 
-  if(empty($vars['head_title']){// If front page, don't display a page title in head_title.
+  if(empty($vars['head_title'])){// If front page, don't display a page title in head_title.
     if ( drupal_is_front_page() ) {
       $vars['head_title_array'] = array('name' => check_plain(variable_get('site_name', 'Drupal')));
       if ( variable_get('site_slogan', '') ) {

--- a/template.php
+++ b/template.php
@@ -52,17 +52,17 @@ function bootstrap_preprocess_html(&$vars) {
     $vars['classes_array'][] = 'with-navbar';
   }
 
-  // If front page, don't display a page title in head_title.
-  if ( drupal_is_front_page() ) {
-    $vars['head_title_array'] = array('name' => check_plain(variable_get('site_name', 'Drupal')));
-    if ( variable_get('site_slogan', '') ) {
-      $vars['head_title_array']['slogan'] = filter_xss_admin(variable_get('site_slogan', ''));
+  if(empty($vars['head_title']){// If front page, don't display a page title in head_title.
+    if ( drupal_is_front_page() ) {
+      $vars['head_title_array'] = array('name' => check_plain(variable_get('site_name', 'Drupal')));
+      if ( variable_get('site_slogan', '') ) {
+        $vars['head_title_array']['slogan'] = filter_xss_admin(variable_get('site_slogan', ''));
+      }
     }
+
+    $vars['head_title'] = implode(' | ', $vars['head_title_array']);
   }
-
-  $vars['head_title'] = implode(' | ', $vars['head_title_array']);
 }
-
 /**
  * Override or insert variables into page.tpl.php
  */


### PR DESCRIPTION
I've started using the "Page Title" module (http://drupal.org/project/page_title), which naturally wants to set the `$vars['page_title']` variable, though the theme currently overrides that.

This pull request simply wraps the code that generates the page title in an `if(empty($vars['page_title']))` to determine if generating a page title is required.

Thanks!
